### PR TITLE
CSV to PHP (later rdf) parser

### DIFF
--- a/csvReader.php
+++ b/csvReader.php
@@ -8,11 +8,23 @@ prediate[from table header] <- $keys[$counter]
 object[table element] <- $data[$counter][$keys[$counter2]]
     - mostly needs cast to literal or true/false?
 */
+
+/*
+Reader for parsing CSV data into PHP associative Arrays
+
+assuming proper table structure:
+    - every line has the same number of elements
+    - seperated by ','
+*/
 class csvReader
 {
     private $keys;    
     private $data;
     
+    /**
+      * constructor, reading in csv file
+      * catching file not found errors
+    */
     public function __construct($path){
         //opening file handle
         $handle = fopen($path,'r');

--- a/csvReader.php
+++ b/csvReader.php
@@ -1,0 +1,46 @@
+<?php
+/*
+assuming:
+subject[building] <- $data[$counter]
+    - overload $counter with building URI
+prediate[from table header] <- $keys[$counter]
+    - needs mapping with URIs to get rid of these strings
+object[table element] <- $data[$counter][$keys[$counter2]]
+    - mostly needs cast to literal or true/false?
+*/
+class csvReader
+{
+    private $keys;    
+    private $data;
+    
+    public function __construct($path){
+        //opening file handle
+        $handle = fopen($path,'r');
+        //initiating target array
+        if($handle == FALSE){
+            throw new Exception("csv file not found");
+        }
+        //table header -> associative array keys
+        $this->keys = fgetcsv($handle, 1000, ",");
+        $rowCounter = 0;
+        //read in every line
+        while (($dataLine = fgetcsv($handle, 1000, ",")) !== FALSE) {
+            //fill in associative array
+            $this->data[$rowCounter] = array();
+            for($columnCounter = 0; $columnCounter < sizeof($dataLine); $columnCounter++){
+                $this->data[$rowCounter][''.$this->keys[$columnCounter]] = $dataLine[$columnCounter];
+            }
+            $rowCounter++;
+        }
+        fclose($handle);
+    }
+    
+    public function getData(){
+        return $this->data;
+    }
+    
+    public function getKeys(){
+        return $this->keys;
+    }
+}
+

--- a/example.php
+++ b/example.php
@@ -1,0 +1,12 @@
+<?php
+include_once('csvReader.php');
+try{
+    $csvReader = new csvReader('le-online-extracted-places.csv');
+}catch(Exception $e){
+    exit("got an Exception: ".$e);
+}
+
+echo "keys = ".PHP_EOL;
+echo var_dump($csvReader->getKeys()).PHP_EOL;
+echo "data = ".PHP_EOL;
+echo var_dump($csvReader->getData());PHP_EOL;


### PR DESCRIPTION
Although a bit redundant in this project, I added a small parser class as we discussed last week.

Bringing in a mapping for the predicates we could easily bring this to RDF now.

w3c offers no mapper for php, only a few Java Servlets, one with GUI, and one with 200+ issues so maybe we should build our own small mapper.
https://www.w3.org/wiki/ConverterToRdf#CSV_.28Comma-Separated_Values.29
